### PR TITLE
version 1.0.2 foreign key lookups with Record class

### DIFF
--- a/Postulate.Lite.Core/Attributes/ReferencesAttribute.cs
+++ b/Postulate.Lite.Core/Attributes/ReferencesAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Postulate.Lite.Core.Attributes
+{
+	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+	public class ReferencesAttribute : Attribute
+	{
+		public ReferencesAttribute(Type primaryType)
+		{
+			PrimaryType = primaryType;
+		}
+
+		public Type PrimaryType { get; private set; }
+
+		/// <summary>
+		/// When creating this relationship, enable cascade deletes
+		/// </summary>
+		public bool CascadeDelete { get; set; }
+	}
+}

--- a/Postulate.Lite.Core/ColumnInfo.cs
+++ b/Postulate.Lite.Core/ColumnInfo.cs
@@ -43,6 +43,12 @@ namespace Postulate.Lite.Core
 				Precision = precisionAttr.Precision;
 				Scale = precisionAttr.Scale;
 			}
+
+			var pkAttr = propertyInfo.GetCustomAttribute<PrimaryKeyAttribute>();
+			if (pkAttr != null)
+			{
+				AllowNull = false;
+			}
 		}
 
 		public ColumnInfo()

--- a/Postulate.Lite.Core/Postulate.Lite.Core.csproj
+++ b/Postulate.Lite.Core/Postulate.Lite.Core.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Attributes\DecimalPrecisionAttribute.cs" />
     <Compile Include="Attributes\IdentityAttribute.cs" />
     <Compile Include="Attributes\PrimaryKeyAttribute.cs" />
+    <Compile Include="Attributes\ReferencesAttribute.cs" />
     <Compile Include="ColumnInfo.cs" />
     <Compile Include="Extensions\TypeExtensions.cs" />
     <Compile Include="Interfaces\IUser.cs" />

--- a/Postulate.Lite.Core/Record.cs
+++ b/Postulate.Lite.Core/Record.cs
@@ -13,6 +13,11 @@ namespace Postulate.Lite.Core
 
 	public abstract class Record
 	{
+		public virtual void LookupForeignKeys(IDbConnection connection)
+		{
+			// do nothing by default
+		}
+
 		public virtual void Validate(IDbConnection connection)
 		{
 			// do nothing by default

--- a/Postulate.Lite.SqlServer/Properties/AssemblyInfo.cs
+++ b/Postulate.Lite.SqlServer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.2.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Postulate.Lite.SqlServer/SqlServerProvider.cs
+++ b/Postulate.Lite.SqlServer/SqlServerProvider.cs
@@ -23,9 +23,10 @@ namespace Postulate.Lite.SqlServer
 
 		protected override string FindCommand<T>(string whereClause)
 		{
+			var type = typeof(T);
 			var props = MappedColumns<T>();
 			var columns = props.Select(pi => new ColumnInfo(pi));
-			return $"SELECT {string.Join(", ", columns.Select(col => ApplyDelimiter(col.ColumnName)))} FROM {ApplyDelimiter(TableName<T>())} WHERE {whereClause}";
+			return $"SELECT {string.Join(", ", columns.Select(col => ApplyDelimiter(col.ColumnName)))} FROM {ApplyDelimiter(TableName<T>())} WHERE {whereClause}";			
 		}
 
 		protected override string InsertCommand<T>()
@@ -71,7 +72,6 @@ namespace Postulate.Lite.SqlServer
 		protected override string TableName<T>()
 		{
 			var type = typeof(T);
-			
 			Dictionary<string, string> parts = new Dictionary<string, string>()
 			{
 				{ "schema", string.Empty },

--- a/Tests/Models/Employee.cs
+++ b/Tests/Models/Employee.cs
@@ -1,13 +1,21 @@
-﻿using Postulate.Lite.Core.Attributes;
+﻿using Postulate.Lite.Core;
+using Postulate.Lite.Core.Attributes;
+using Postulate.Lite.SqlServer;
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Data;
 
 namespace Tests.Models
 {
 	[Identity(nameof(Id))]
-	public class Employee
-	{
+	public class Employee : Record
+	{		
+		[References(typeof(Organization))]
+		public int OrganizationId { get; set; }
+
+		public Organization Organization { get; set; }
+
 		[MaxLength(50)]
 		[Required]
 		public string FirstName { get; set; }
@@ -25,5 +33,10 @@ namespace Tests.Models
 		public bool IsActive { get; set; } = true;
 
 		public int Id { get; set; }
+
+		public override void LookupForeignKeys(IDbConnection connection)
+		{
+			Organization = connection.Find<Organization>(OrganizationId);
+		}
 	}
 }

--- a/Tests/Models/Organization.cs
+++ b/Tests/Models/Organization.cs
@@ -1,0 +1,15 @@
+﻿using Postulate.Lite.Core.Attributes;
+using System.ComponentModel.DataAnnotations;
+
+namespace Tests.Models
+{
+	[Identity(nameof(Id))]
+	public class Organization
+	{
+		[MaxLength(50)]
+		[PrimaryKey]
+		public string Name { get; set; }
+
+		public int Id { get; set; }
+	}
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -60,6 +60,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Models\Organization.cs" />
     <Compile Include="SqlServer\Crud.cs" />
     <Compile Include="Models\Employee.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
does not implement FK DDL in table creation, just allows FK lookup during Finds
I couldn't do it entirely dynamically within the CommandProvider
Instead I added an override on the Record class. So, you have to do it somewhat manually, but the code is clear.